### PR TITLE
FEC-11222 Marking ExoTimeoutException as Non-Fatal 

### DIFF
--- a/youboraplugin/src/main/java/com/kaltura/playkit/plugins/youbora/PKYouboraPlayerAdapter.java
+++ b/youboraplugin/src/main/java/com/kaltura/playkit/plugins/youbora/PKYouboraPlayerAdapter.java
@@ -14,6 +14,7 @@ package com.kaltura.playkit.plugins.youbora;
 
 import android.text.TextUtils;
 
+import com.kaltura.android.exoplayer2.ExoTimeoutException;
 import com.kaltura.playkit.BuildConfig;
 import com.kaltura.playkit.MessageBus;
 import com.kaltura.playkit.PKError;
@@ -144,7 +145,12 @@ class PKYouboraPlayerAdapter extends PlayerAdapter<Player> {
         if ((error.errorType) instanceof PKPlayerErrorType) {
             PKPlayerErrorType errorType = (PKPlayerErrorType)error.errorType;
             String errorCode = String.valueOf(errorType.errorCode);
-            fireFatalError(errorCode, exceptionCauseBuilder.toString() + " - " + exceptionClass, errorMetadata, playerErrorException);
+            
+            if (playerErrorException != null && playerErrorException.getCause() instanceof ExoTimeoutException) {
+                fireError(errorCode, exceptionCauseBuilder.toString() + " - " + exceptionClass, errorMetadata, playerErrorException);
+            } else {
+                fireFatalError(errorCode, exceptionCauseBuilder.toString() + " - " + exceptionClass, errorMetadata, playerErrorException);
+            }
         } else {
             fireFatalError(event.eventType().name(), exceptionCauseBuilder.toString() + " - " + exceptionClass , errorMetadata, playerErrorException);
         }

--- a/youboraplugin/src/main/java/com/kaltura/playkit/plugins/youbora/PKYouboraPlayerAdapter.java
+++ b/youboraplugin/src/main/java/com/kaltura/playkit/plugins/youbora/PKYouboraPlayerAdapter.java
@@ -110,7 +110,6 @@ class PKYouboraPlayerAdapter extends PlayerAdapter<Player> {
     }
 
     private void sendErrorHandler(PKEvent event) {
-
         PlayerEvent.Error errorEvent = (PlayerEvent.Error) event;
         String errorMetadata = (errorEvent != null && errorEvent.error != null) ? errorEvent.error.message : PLAYER_ERROR_STR;
 
@@ -145,7 +144,6 @@ class PKYouboraPlayerAdapter extends PlayerAdapter<Player> {
         if ((error.errorType) instanceof PKPlayerErrorType) {
             PKPlayerErrorType errorType = (PKPlayerErrorType)error.errorType;
             String errorCode = String.valueOf(errorType.errorCode);
-            
             if (playerErrorException != null && playerErrorException.getCause() instanceof ExoTimeoutException) {
                 fireError(errorCode, exceptionCauseBuilder.toString() + " - " + exceptionClass, errorMetadata, playerErrorException);
             } else {


### PR DESCRIPTION
This change is not required because for non-fatal, we don't fire any event. This check is on top level.